### PR TITLE
updated Overview of Title Storage

### DIFF
--- a/xbox-live-docs-pr/storage-platform/xbox-live-title-storage/xbox-live-title-storage.md
+++ b/xbox-live-docs-pr/storage-platform/xbox-live-title-storage/xbox-live-title-storage.md
@@ -28,30 +28,14 @@ Some of the high-level features of Xbox Live title storage include, but are not 
 
 ## Types of storage
 
-For Managed Partners:
-
 | Storage Type       | Quota (Managed Partners) | Quota (Creators Program) |  Purpose                                                                                                                                                      | Platforms                                                                                           | Users                                       |
 |--------------------|--------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|---------------------------------------------|
 | Trusted Platform   | 256 MB per user | 64 MB per user    | Per-user data such as saved games or game state for play/pause/resume. More secure, but with platform restrictions. | Any platform may read, but only Xbox One, Xbox 360, or Windows Phone may write.  | Configurable to public or owner only.       |
-| Universal Platform | 64 MB per user | 64 MB per user    | Per-user data such as saved games or game state for play/pause/resume. | Any platform may write, but only platforms other than Xbox One, Xbox 360 or Windows Phone may read. | Configurable to public or owner only.       |
+| Universal Platform | 64 MB per user | 64 MB per user    | Per-user data such as saved games or game state for play/pause/resume. | Any platform may read or write. | Configurable to public or owner only.       |
 | Global             | 256 MB | 256 MB            | Data that everyone can read, such as rosters, maps, challenges, or art resources. | Only writeable via the Xbox Developer Portal or Partner Center, any platform may read.                                | All users may read.
 
 
-### Deprecated storage Types
-
-The following storage types are deprecated.
-They are supported only for titles that are currently using them.
-They are not available for new titles.
-
-| Storage Type       | Quota  |   Purpose                                                                                                                                                      | Platforms                                                                                           | Users                                       |
-|--------------------|--------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|---------------------------------------------|
-| JSON               | 64 MB per user     | Per-user data such as saved games or game state for play/pause/resume. More secure, no platform restrictions, but with data format restrictions (JSON only). | Any platform may read or write.                                                                     | Configurable to public or owner only.       |
-| Device             | 64 MB per device   | Data specific to a device such as settings or device preferences.                                                                                            | Only Xbox One, Xbox 360, or Windows Phone may write. Only the device that wrote the data may read.  | All users may read.                         |
-| Session Storage    | 256 MB per session | Data for anyone joined to a particular multiplayer game session.                                                                                             | Any platform that may join the session.                                                             | All users in the session may read or write. |
-
-
 <a name="ID4ECF"></a>
-
 ## Types of data
 
 Games specify the type of data to use in the **{type}** parameter of a GET or PUT method.


### PR DESCRIPTION
Changed the list of platforms that can read/write to Universal Platform storage--Xbox One consoles can read from Universal (that was a bug in the docs), and there is no point in mentioning X360 or WinPhone because neither of those platforms are seeing active development. This way it reads much cleaner--Universal Storage works with Any Platform.
Removed section on Deprecated storage types--if a developer is already using those, they can contact us directly. Showing the JSON storage type under Deprecated was particularly confusing, because we still allow JSON uploads to our other storage types (there's just a specific URL with JSON in it that we don't support anymore).