### PR TITLE
Name code snippet correctly

### DIFF
--- a/xbox-live-docs-pr/api-ref/xbox-live-rest/uri/presence/uri-usersxuidget.md
+++ b/xbox-live-docs-pr/api-ref/xbox-live-rest/uri/presence/uri-usersxuidget.md
@@ -124,7 +124,7 @@ No objects are sent in the body of this request.
 If there is no existing record for the user, a record with no devices is returned.
 
 
-```cpp
+```json
 {
   xuid:"0123456789",
   state:"online",


### PR DESCRIPTION
It's an example of a JavaScript object, not C++ code.